### PR TITLE
SCRUM-17: add worker + local infra (RabbitMQ, Mailpit) + docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+RABBITMQ_URL="amqp://guest:guest@localhost:5672/"
+RABBITMQ_EXCHANGE=email
+RABBITMQ_EXCHANGE_TYPE=direct
+RABBITMQ_ROUTING_KEY=send
+
+MAIL_SERVER=localhost
+MAIL_PORT=1025
+MAIL_DEFAULT_SENDER=noreply@example.local

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,9 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# VS Code
+.vscode/
+
+# Infra data
+infra/data/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cp .env.example .env
 ## 3) Run the Flask worker
 
 ```bash
-flask --app app worker
+flask worker
 ```
 
 * Runs until you stop it (Ctrl+C).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,147 @@
+# Email Worker — Dev Setup & Test Guide
+
+This worker consumes messages from **RabbitMQ** and sends emails via **SMTP**.
+For local development we use **Mailpit** as an SMTP catcher (no real emails go out).
+
+---
+
+## Prerequisites
+
+* Docker
+* Python 3.10+
+
+---
+
+## 1) Start infra: RabbitMQ & Mailpit
+<!--[Sign in with app passwords - Gmail Help](https://support.google.com/mail/answer/185833)-->
+```bash
+cd infra
+docker compose up -d
+cd ..
+```
+
+**Ports**
+
+* RabbitMQ AMQP: `5672`
+* RabbitMQ UI: `http://localhost:15672` (user/pass: `guest` / `guest`)
+* Mailpit SMTP: `1025`
+* Mailpit UI: `http://localhost:8025`
+
+> Tip: `docker compose logs -f` (in `infra/`) tails infra logs.
+
+---
+
+## 2) Install dependencies & set environment
+
+Create/activate a virtual environment, then:
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+---
+
+## 3) Run the Flask worker
+
+```bash
+flask --app app worker
+```
+
+* Runs until you stop it (Ctrl+C).
+
+> If you see “`SMTP AUTH extension not supported by server`”, you’re hitting Mailpit with creds. For dev, **leave `MAIL_USERNAME/MAIL_PASSWORD` empty** and **TLS/SSL false**.
+
+---
+
+## 4) Publish a test message (routing key: `send`)
+
+The worker expects a JSON payload like:
+
+```json
+{
+  "to": "you@example.com",
+  "subject": "Test",
+  "html": "<b>Hello</b>"
+}
+```
+
+You can publish via **any** of the following:
+
+### 4.a) RabbitMQ Management UI (easiest)
+
+1. Open [http://localhost:15672](http://localhost:15672) → log in (`guest`/`guest`).
+2. Go to **Exchanges** → click `email`.
+3. In **Publish message**:
+
+   * **Routing key**: `send`
+   * **Payload**: paste the JSON above
+   * **Properties**: (optional) `content_type` = `application/json`
+4. Click **Publish message** → you should see the worker log a delivery.
+
+### 4.b) HTTP API with cURL (reliable)
+
+For the default vhost `/` (URL-encoded as `%2F`):
+
+```bash
+curl -u guest:guest \
+  -H "Content-Type: application/json" \
+  -X POST http://localhost:15672/api/exchanges/%2F/email/publish \
+  -d '{
+    "properties": { "content_type": "application/json", "delivery_mode": 2 },
+    "routing_key": "send",
+    "payload": "eyJ0byI6InlvdUBleGFtcGxlLmNvbSIsInN1YmplY3QiOiJUZXN0IiwiaHRtbCI6IjxiPkhlbGxvPC9iPiJ9",
+    "payload_encoding": "base64"
+  }'
+```
+
+> The `payload` above is base64 for `{"to":"you@example.com","subject":"Test","html":"<b>Hello</b>"}`.
+> Using base64 avoids “`not_json`” errors caused by quoting/escaping.
+
+### 4.c) Postman
+
+Import the collection for email serive from [fa-api-collections](https://github.com/forum-app-team/fa-api-collections).
+
+* **Auth** tab → **Basic Auth** (`guest`/`guest`)
+* **POST** `http://localhost:15672/api/exchanges/%2F/email/publish`
+* **Body (raw JSON)** (base64 approach):
+
+  ```json
+  {
+    "properties": { "content_type": "application/json", "delivery_mode": 2 },
+    "routing_key": "send",
+    "payload": "{{payload_b64}}",
+    "payload_encoding": "base64"
+  }
+  ```
+* **Pre-request Script**:
+
+  ```javascript
+  const data = {
+    to: 'you@example.com',
+    subject: 'Test',
+    html: '<b>Hello</b>'
+  };
+  pm.variables.set('payload_b64', Buffer.from(JSON.stringify(data)).toString('base64'));
+  ```
+
+---
+
+## 5) View the email
+
+Open **Mailpit UI**:
+[http://localhost:8025](http://localhost:8025)
+
+You should see the message in the inbox. Click to preview the HTML.
+
+---
+
+## Clean up
+
+```bash
+# stop worker
+Ctrl+C
+
+# stop infra (from infra/)
+docker compose down
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,17 @@
+from flask import Flask
+from config import Config
+from extensions import mail
+from flask.cli import with_appcontext
+from worker import run_consumer
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    mail.init_app(app)
+
+    @app.cli.command("worker")
+    @with_appcontext
+    def worker():
+        """Start the email queue consumer."""
+        run_consumer(app=app)
+    return app

--- a/config.py
+++ b/config.py
@@ -1,0 +1,15 @@
+import os
+
+class Config:
+    MAIL_SERVER = os.getenv("MAIL_SERVER", "localhost")
+    MAIL_PORT = int(os.getenv("MAIL_PORT", "1025"))
+    MAIL_USE_TLS = os.getenv("MAIL_USE_TLS", "false").lower() == "true"
+    MAIL_USE_SSL = os.getenv("MAIL_USE_SSL", "false").lower() == "true"
+    MAIL_USERNAME = os.getenv("MAIL_USERNAME")
+    MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
+    MAIL_DEFAULT_SENDER = os.getenv("MAIL_DEFAULT_SENDER", "noreply@example.local")
+
+    RABBITMQ_URL = os.getenv("RABBITMQ_URL")
+    RABBITMQ_EXCHANGE = os.getenv("RABBITMQ_EXCHANGE")
+    RABBITMQ_EXCHANGE_TYPE = os.getenv("RABBITMQ_EXCHANGE_TYPE")
+    RABBITMQ_ROUTING_KEY = os.getenv("RABBITMQ_ROUTING_KEY")

--- a/extensions.py
+++ b/extensions.py
@@ -1,0 +1,8 @@
+from flask_mail import Mail, Message
+
+mail = Mail()
+
+def send_email(to, subject, html):
+    msg = Message(subject, recipients=[to])
+    msg.html = html
+    mail.send(msg)   # requires an active app context

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  rabbitmq:
+    image: rabbitmq:4-management
+    container_name: forum-rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672" # UI http://localhost:15672
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-guest}
+    volumes:
+      - ./data/rabbitmq:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # UI http://localhost:8025
+    environment:
+      MP_DATABASE: /data/mailpit.db   # persist captured emails
+      # Optional retention:
+      # MP_MAX_MESSAGES: "5000"
+      # MP_MAX_AGE: "14d"
+    volumes:
+      - ./data/mailpit:/data
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8025/health"]  # Mailpit exposes /health
+      interval: 30s
+      timeout: 5s
+      retries: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.1.2
+Flask-Mail==0.10.0
+pika==1.3.2
+python-dotenv==1.1.1

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,34 @@
+import json
+import time
+import pika
+
+def run_consumer(app, once: bool = False):
+    """Start RabbitMQ consumer; requires Flask app to push context."""
+    from extensions import send_email
+    url = app.config["RABBITMQ_URL"]
+    exchange = app.config["RABBITMQ_EXCHANGE"]
+    exchange_type = app.config["RABBITMQ_EXCHANGE_TYPE"]
+    routing_key = app.config["RABBITMQ_ROUTING_KEY"]
+    queue = f'{exchange}.{routing_key}'
+
+    with app.app_context():
+        while True:
+            try:
+                conn = pika.BlockingConnection(pika.URLParameters(url))
+                ch = conn.channel()
+                ch.exchange_declare(exchange=exchange, exchange_type=exchange_type, durable=True)
+                ch.queue_declare(queue=queue, durable=True)
+                ch.queue_bind(exchange=exchange, queue=queue, routing_key=routing_key)
+                ch.basic_qos(prefetch_count=10)
+
+                def handle(_ch, method, props, body):
+                    data = json.loads(body)
+                    # expected payload example: {"to":"user@x.com","subject":"...","html":"..."}
+                    send_email(data["to"], data.get("subject", "Notification"), data["html"])
+                    _ch.basic_ack(method.delivery_tag)
+
+                ch.basic_consume(queue, on_message_callback=handle)
+                ch.start_consuming()
+            except Exception as e:
+                print("Consumer error:", e, "— retrying in 5s")
+                time.sleep(5)


### PR DESCRIPTION
### Summary

Adds a Flask-based **email queue worker** and local **Docker Compose** for **RabbitMQ** (AMQP) and **Mailpit** (SMTP catcher). Includes a concise **README** with setup & test steps.

### Changes

* 🐇 `infra/docker-compose.yml`: RabbitMQ + Mailpit with persisted data.
* ✉️ `flask worker` command: email queue **consumer** (`email` exchange → `email.send` queue).
* 📘 `README.md`: instructions for running infra, worker, and publishing test messages.

### How to test

1. Start infra:

```bash
cd infra && docker compose up -d && cd ..
```

2. Install & env:

```bash
pip install -r requirements.txt
cp .env.example .env   # defaults for Mailpit + RabbitMQ
```

3. Run worker:

```bash
flask worker
```

4. Publish (routing key `send`) via RMQ UI (`http://localhost:15672`) or API:

```bash
curl -u guest:guest -H "Content-Type: application/json" \
  -X POST http://localhost:15672/api/exchanges/%2F/email/publish \
  -d '{"properties":{"content_type":"application/json","delivery_mode":2},
       "routing_key":"send",
       "payload":"{\"to\":\"you@example.com\",\"subject\":\"Test\",\"html\":\"<b>Hello</b>\"}",
       "payload_encoding":"string"}'
```

5. Verify email in Mailpit UI: `http://localhost:8025`.

### Notes

* Worker is a background process (no HTTP endpoints).
* Dev-only SMTP uses Mailpit (no real emails sent).
* Ready to switch to real SMTP in prod via env vars.
